### PR TITLE
fix remainder loop, add partial shuffle

### DIFF
--- a/include/simdxorshift128plus.h
+++ b/include/simdxorshift128plus.h
@@ -72,6 +72,12 @@ void avx_xorshift128plus_jump(avx_xorshift128plus_key_t * key);
  */
 void  avx_xorshift128plus_shuffle32(avx_xorshift128plus_key_t *key, uint32_t *storage, uint32_t size);
 
+/**
+ * Partial Fisher-Yates shuffle, shuffling  "size" 32-bit  values in "storage". You must provide the key for
+ * randomness. Stops shuffling after finalizing all elements in [lower_index_inclusive, size).
+ */
+void  avx_xorshift128plus_shuffle32_partial(avx_xorshift128plus_key_t *key, uint32_t *storage, uint32_t size, uint32_t lower_index_inclusive);
+
 #if defined(__AVX512F__) 
 
 struct avx512_xorshift128plus_key_s {

--- a/include/xorshift128plus.h
+++ b/include/xorshift128plus.h
@@ -55,4 +55,7 @@ void xorshift128plus_jump(xorshift128plus_key_t * key);
 /* Fisher-Yates shuffle, shuffling an array of 32-bit values, uses the provided key */
 void  xorshift128plus_shuffle32(xorshift128plus_key_t * key, uint32_t *storage, uint32_t size);
 
+/* Partial Fisher-Yates shuffle, shuffling  "size" 32-bit  values in "storage". You must provide the key for randomness. Applies shuffle to elements in [lower_index_inclusive, size). */
+void  xorshift128plus_shuffle32_partial(xorshift128plus_key_t * key, uint32_t *storage, uint32_t size, uint32_t lower_index_inclusive);
+
 #endif

--- a/src/xorshift128plus.c
+++ b/src/xorshift128plus.c
@@ -48,9 +48,14 @@ static uint32_t xorshift128plus_bounded(xorshift128plus_key_t * key, uint32_t bo
 
 /* Fisher-Yates shuffle, shuffling an array of integers, uses the provided key */
 void  xorshift128plus_shuffle32(xorshift128plus_key_t * key, uint32_t *storage, uint32_t size) {
+    xorshift128plus_shuffle32_partial(key, storage, size, 1);
+}
+
+void  xorshift128plus_shuffle32_partial(xorshift128plus_key_t * key, uint32_t *storage, uint32_t size, uint32_t lower_index_inclusive) {
     uint32_t i;
     uint32_t nextpos1, nextpos2;
-    for (i=size; i>2; i-=2) {
+    if (lower_index_inclusive==0) lower_index_inclusive=1;
+    for (i=size; i>(lower_index_inclusive+1); i-=2) {
     	xorshift128plus_bounded_two_by_two(key,i,i-1,&nextpos1,&nextpos2);
         const uint32_t tmp1 = storage[i-1];// likely in cache
         const uint32_t val1 = storage[nextpos1]; // could be costly
@@ -63,7 +68,7 @@ void  xorshift128plus_shuffle32(xorshift128plus_key_t * key, uint32_t *storage, 
         storage[nextpos2] = tmp2; // you might have to read this store later
 
     }
-    if(i>1) {
+    if(i>lower_index_inclusive) {
     	const uint32_t nextpos = xorshift128plus_bounded(key,i);
     	const uint32_t tmp = storage[i-1];// likely in cache
     	const uint32_t val = storage[nextpos]; // could be costly


### PR DESCRIPTION
``avx_xorshift128plus_shuffle32`` seem to be limited to buffers with length that is multiple of 8. Or am I missing something? I've got a crash, and then added reminder loop - then things seem to work correctly.
Also, add an option for a partial shuffle (both in avx and non-avx versions).